### PR TITLE
Implement advanced Sudoku solving techniques

### DIFF
--- a/src/grid/cell.rs
+++ b/src/grid/cell.rs
@@ -23,11 +23,13 @@ impl Cell {
         self.value
     }
 
-    pub fn remove_possibility(&mut self, value: i32) {
+    pub fn remove_possibility(&mut self, value: i32) -> bool {
         if self.value > 0 {
-            return;
+            return false;
         }
-       self.possible_values.retain(|&x| x != value);
+        let len_before = self.possible_values.len();
+        self.possible_values.retain(|&x| x != value);
+        self.possible_values.len() < len_before
     }
 
     pub fn possibilities(& self) -> &Vec<i32> {

--- a/src/grid/grid.rs
+++ b/src/grid/grid.rs
@@ -57,9 +57,9 @@ impl<'a> Grid {
         return Ok(());
     }
 
-    pub fn remove_possibility(&mut self, x:i32, y: i32, value: i32){
+    pub fn remove_possibility(&mut self, x:i32, y: i32, value: i32) -> bool {
         let index = (y * 9 + x) as usize;
-        self.cells[index].remove_possibility(value);
+        self.cells[index].remove_possibility(value)
     }
     
     pub fn render_grid(&self, ui: &mut Ui, edit_values: &mut EditingValues){

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,6 @@ use solver::Solver;
 
 // TODO:
 // * Editing in cell, rather than at bottom
-// * Additional "solve" logic
-//  * If only cell in row, col or block that can have that value, then set it
-//  * Evaluate other solve techniques
 // * Handle impossible grids
 // * Handle logic fails :
 //  * cells with no valid value (possibilities().len == 0)

--- a/src/solver/solver.rs
+++ b/src/solver/solver.rs
@@ -1,73 +1,127 @@
 use crate::Grid;
-use std::{collections::{HashMap, HashSet}, default, sync::{Arc, Mutex}};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
 pub struct Solver {
 }
 
-#[derive(Default)]
-pub struct Cell_Ref{
+#[derive(Default, Clone)]
+struct CellRef {
     x: i32,
     y: i32,
 }
 
-#[derive(Default)]
-pub struct Value_To_Cell_Refs{
-    value: i32,
-    cell_refs: Vec<Cell_Ref>
-}
-
-
 impl Solver {
-    pub fn solve(thread_grid: Arc<Mutex<Grid>>){
+    pub fn solve(thread_grid: Arc<Mutex<Grid>>) {
         let mut iterations = 0;
-        let mut value_changed = true;
-        while (value_changed){
-            value_changed = false;
-            Self::set_only_one_possibility_values(&thread_grid, &mut value_changed);
-            Self::set_when_only_one_cell_in_row_supports_value(&thread_grid, &mut value_changed);
-            Self::set_when_only_one_cell_in_column_supports_value(&thread_grid, &mut value_changed);
-            Self::set_when_only_one_cell_in_block_supports_value(&thread_grid, &mut value_changed);
+        let mut progress = true;
+        while progress {
+            progress = false;
+
+            // Candidate elimination techniques (reduce possibilities without setting values)
+            Self::reduce_naked_pairs_in_all_units(&thread_grid, &mut progress);
+            Self::reduce_naked_triples_in_all_units(&thread_grid, &mut progress);
+            Self::reduce_hidden_pairs_in_all_units(&thread_grid, &mut progress);
+            Self::reduce_pointing_pairs(&thread_grid, &mut progress);
+            Self::reduce_box_line(&thread_grid, &mut progress);
+
+            // Value-setting techniques
+            Self::set_only_one_possibility_values(&thread_grid, &mut progress);
+            Self::set_when_only_one_cell_in_row_supports_value(&thread_grid, &mut progress);
+            Self::set_when_only_one_cell_in_column_supports_value(&thread_grid, &mut progress);
+            Self::set_when_only_one_cell_in_block_supports_value(&thread_grid, &mut progress);
+
             iterations += 1;
         }
         println!("Ending the solve process after {} iteration(s).", iterations);
     }
 
-    fn set_only_one_possibility_values(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool){
+    // --- Helper methods for building cell reference sets ---
+
+    fn row_cells(row: i32) -> Vec<CellRef> {
+        (0..9).map(|col| CellRef { x: col, y: row }).collect()
+    }
+
+    fn col_cells(col: i32) -> Vec<CellRef> {
+        (0..9).map(|row| CellRef { x: col, y: row }).collect()
+    }
+
+    fn block_cells(bx: i32, by: i32) -> Vec<CellRef> {
+        let mut cells = Vec::new();
+        for dy in 0..3 {
+            for dx in 0..3 {
+                cells.push(CellRef { x: bx * 3 + dx, y: by * 3 + dy });
+            }
+        }
+        cells
+    }
+
+    fn all_units() -> Vec<Vec<CellRef>> {
+        let mut units = Vec::new();
+        for i in 0..9 {
+            units.push(Self::row_cells(i));
+            units.push(Self::col_cells(i));
+        }
+        for bx in 0..3 {
+            for by in 0..3 {
+                units.push(Self::block_cells(bx, by));
+            }
+        }
+        units
+    }
+
+    /// Read possibilities for all cells in a unit in a single lock.
+    /// Returns empty Vec for solved cells.
+    fn read_unit_possibilities(grid: &Arc<Mutex<Grid>>, cells: &[CellRef]) -> Vec<Vec<i32>> {
+        let g = grid.lock().unwrap();
+        cells.iter().map(|cr| {
+            let cell = g.get_cell(cr.x, cr.y).unwrap();
+            if cell.get_value() > 0 {
+                Vec::new()
+            } else {
+                cell.possibilities().clone()
+            }
+        }).collect()
+    }
+
+    // =========================================================================
+    // Existing value-setting techniques
+    // =========================================================================
+
+    /// Naked singles: if a cell has only one possibility left, set it.
+    fn set_only_one_possibility_values(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool) {
         for y in 0..9 {
             for x in 0..9 {
-                // sleep(Duration::from_millis(20));
                 let mut not_set = true;
-                let possibilities =
-                {
+                let possibilities = {
                     let in_grid = thread_grid.lock().unwrap();
                     let cell = (*in_grid).get_cell(x, y).unwrap();
-
                     if cell.get_value() > 0 {
                         not_set = false;
                     }
-                    cell.possibilities().clone() // Clone inside limited scope
+                    cell.possibilities().clone()
                 };
                 if possibilities.len() == 1 && not_set {
                     let mut in_grid = thread_grid.lock().unwrap();
-                    (*in_grid).set_cell(x, y, possibilities[0]);
+                    let _ = (*in_grid).set_cell(x, y, possibilities[0]);
                     *value_changed = true;
                 }
             }
         }
-    }   
+    }
 
-    fn set_when_only_one_cell_in_column_supports_value(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool){
+    /// Hidden singles in rows: if only one cell in a row can hold a value, set it.
+    fn set_when_only_one_cell_in_row_supports_value(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool) {
         for y in 0..9 {
             let mut counts: HashMap<i32, usize> = HashMap::new();
             for x in 0..9 {
-                let possibilities =
-                {
+                let possibilities = {
                     let in_grid = thread_grid.lock().unwrap();
                     let cell = (*in_grid).get_cell(x, y).unwrap();
-
                     if cell.get_value() > 0 {
-                       continue; // ignore set values 
+                       continue;
                     }
-                    cell.possibilities().clone() // Clone inside limited scope
+                    cell.possibilities().clone()
                 };
                 for p in possibilities {
                     *counts.entry(p).or_insert(0) += 1;
@@ -75,42 +129,40 @@ impl Solver {
             }
             let unique_numbers: Vec<i32> = counts
                 .iter()
-                .filter(|&(_, &count)| count == 1) // Keep only values with count == 1
-                .map(|(&num, _)| num) // Extract the keys
+                .filter(|&(_, &count)| count == 1)
+                .map(|(&num, _)| num)
                 .collect();
             let unique_hash: HashSet<_> = unique_numbers.iter().cloned().collect();
 
-            for x in 0..9 { 
-                let possibilities =
-                {
+            for x in 0..9 {
+                let possibilities = {
                     let in_grid = thread_grid.lock().unwrap();
                     let cell = (*in_grid).get_cell(x, y).unwrap();
-                    cell.possibilities().clone() // Clone inside limited scope
+                    cell.possibilities().clone()
                 };
                 let pos_hash: HashSet<_> = possibilities.iter().cloned().collect();
                 let overlap: Vec<i32> = pos_hash.intersection(&unique_hash).cloned().collect();
-                if (overlap.len() == 1) {
+                if overlap.len() == 1 {
                     let mut in_grid = thread_grid.lock().unwrap();
-                    (*in_grid).set_cell(x, y, overlap[0]);
+                    let _ = (*in_grid).set_cell(x, y, overlap[0]);
                     *value_changed = true;
                 }
             }
         }
     }
 
-    fn set_when_only_one_cell_in_row_supports_value(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool){
-        for y in 0..9 {
+    /// Hidden singles in columns: if only one cell in a column can hold a value, set it.
+    fn set_when_only_one_cell_in_column_supports_value(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool) {
+        for x in 0..9 {
             let mut counts: HashMap<i32, usize> = HashMap::new();
-            for x in 0..9 {
-                let possibilities =
-                {
+            for y in 0..9 {
+                let possibilities = {
                     let in_grid = thread_grid.lock().unwrap();
                     let cell = (*in_grid).get_cell(x, y).unwrap();
-
                     if cell.get_value() > 0 {
-                       continue; // ignore set values 
+                       continue;
                     }
-                    cell.possibilities().clone() // Clone inside limited scope
+                    cell.possibilities().clone()
                 };
                 for p in possibilities {
                     *counts.entry(p).or_insert(0) += 1;
@@ -118,46 +170,42 @@ impl Solver {
             }
             let unique_numbers: Vec<i32> = counts
                 .iter()
-                .filter(|&(_, &count)| count == 1) // Keep only values with count == 1
-                .map(|(&num, _)| num) // Extract the keys
+                .filter(|&(_, &count)| count == 1)
+                .map(|(&num, _)| num)
                 .collect();
             let unique_hash: HashSet<_> = unique_numbers.iter().cloned().collect();
 
-            for x in 0..9 { 
-                let possibilities =
-                {
+            for y in 0..9 {
+                let possibilities = {
                     let in_grid = thread_grid.lock().unwrap();
                     let cell = (*in_grid).get_cell(x, y).unwrap();
-                    cell.possibilities().clone() // Clone inside limited scope
+                    cell.possibilities().clone()
                 };
                 let pos_hash: HashSet<_> = possibilities.iter().cloned().collect();
                 let overlap: Vec<i32> = pos_hash.intersection(&unique_hash).cloned().collect();
-                if (overlap.len() == 1) {
+                if overlap.len() == 1 {
                     let mut in_grid = thread_grid.lock().unwrap();
-                    (*in_grid).set_cell(x, y, overlap[0]);
+                    let _ = (*in_grid).set_cell(x, y, overlap[0]);
                     *value_changed = true;
                 }
             }
         }
     }
 
-    fn set_when_only_one_cell_in_block_supports_value(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool){
-        // Iterate 9 blocks
-        // do a 0..2 cols, and rows from each start of block, and then the logic is just the same as above
+    /// Hidden singles in blocks: if only one cell in a 3x3 block can hold a value, set it.
+    fn set_when_only_one_cell_in_block_supports_value(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool) {
         for x in 0..3 {
             for y in 0..3 {
                 let mut counts: HashMap<i32, usize> = HashMap::new();
                 for x1 in 0..3 {
                     for y1 in 0..3 {
-                        let possibilities =
-                        {
+                        let possibilities = {
                             let in_grid = thread_grid.lock().unwrap();
                             let cell = (*in_grid).get_cell(x*3+x1, y*3+y1).unwrap();
-
                             if cell.get_value() > 0 {
-                                continue; // ignore set values 
+                                continue;
                             }
-                            cell.possibilities().clone() // Clone inside limited scope
+                            cell.possibilities().clone()
                         };
                         for p in possibilities {
                             *counts.entry(p).or_insert(0) += 1;
@@ -166,25 +214,24 @@ impl Solver {
                 }
                 let unique_numbers: Vec<i32> = counts
                     .iter()
-                    .filter(|&(_, &count)| count == 1) // Keep only values with count == 1
-                    .map(|(&num, _)| num) // Extract the keys
+                    .filter(|&(_, &count)| count == 1)
+                    .map(|(&num, _)| num)
                     .collect();
                 let unique_hash: HashSet<_> = unique_numbers.iter().cloned().collect();
 
-                for x1 in 0..3 { 
+                for x1 in 0..3 {
                     for y1 in 0..3 {
-                        let possibilities =
-                        {
+                        let possibilities = {
                             let in_grid = thread_grid.lock().unwrap();
                             let cell = (*in_grid).get_cell(x*3+x1, y*3+y1).unwrap();
-                            cell.possibilities().clone() // Clone inside limited scope
+                            cell.possibilities().clone()
                         };
                         let pos_hash: HashSet<_> = possibilities.iter().cloned().collect();
                         let overlap: Vec<i32> = pos_hash.intersection(&unique_hash).cloned().collect();
-                        if (overlap.len() == 1) {
-                        let mut in_grid = thread_grid.lock().unwrap();
-                        (*in_grid).set_cell(x*3+x1, y*3+y1, overlap[0]);
-                        *value_changed = true;
+                        if overlap.len() == 1 {
+                            let mut in_grid = thread_grid.lock().unwrap();
+                            let _ = (*in_grid).set_cell(x*3+x1, y*3+y1, overlap[0]);
+                            *value_changed = true;
                         }
                     }
                 }
@@ -192,42 +239,271 @@ impl Solver {
         }
     }
 
-    fn reduce_possible_values_for_mutual_pairs_in_block(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool){
-        // find the set of cells for each block, put mut refs to them in a Vec, and pass to the common method.
+    // =========================================================================
+    // Naked Pairs: if two cells in a unit share the same two candidates,
+    // those values can be removed from all other cells in the unit.
+    // =========================================================================
+
+    fn reduce_naked_pairs_in_all_units(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        for unit in Self::all_units() {
+            *changed |= Self::reduce_naked_pairs_in_unit(grid, &unit);
+        }
     }
 
-    fn reduce_possible_values_for_mutual_pairs_in_row(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool){
-        for row in 0..9
-        {
-            // pull cells from row into a Vec and pass to common method.
-            let mut cells: Vec<Cell_Ref> = Vec::new();
-            for col in 0..9
-            {
-                cells.push(Cell_Ref {
-                    x: col,
-                    y: row
-                });
+    fn reduce_naked_pairs_in_unit(grid: &Arc<Mutex<Grid>>, cells: &[CellRef]) -> bool {
+        let mut changed = false;
+        let cell_poss = Self::read_unit_possibilities(grid, cells);
+
+        // Find cells with exactly 2 possibilities
+        let pairs: Vec<(usize, &Vec<i32>)> = cell_poss.iter().enumerate()
+            .filter(|(_, poss)| poss.len() == 2)
+            .collect();
+
+        // Check for matching pairs
+        for i in 0..pairs.len() {
+            for j in (i + 1)..pairs.len() {
+                let mut a = pairs[i].1.clone();
+                let mut b = pairs[j].1.clone();
+                a.sort();
+                b.sort();
+                if a == b {
+                    let v1 = a[0];
+                    let v2 = a[1];
+                    let idx_a = pairs[i].0;
+                    let idx_b = pairs[j].0;
+                    // Remove these values from all other cells in the unit
+                    let mut g = grid.lock().unwrap();
+                    for (k, cr) in cells.iter().enumerate() {
+                        if k != idx_a && k != idx_b {
+                            changed |= g.remove_possibility(cr.x, cr.y, v1);
+                            changed |= g.remove_possibility(cr.x, cr.y, v2);
+                        }
+                    }
+                }
             }
-            *value_changed |= Self::reduce_possible_values_for_mutual_pairs_in_a_nine_cell_set(thread_grid, cells);
+        }
+        changed
+    }
+
+    // =========================================================================
+    // Naked Triples: if three cells in a unit have candidates that are a subset
+    // of exactly three values, those values can be removed from other cells.
+    // =========================================================================
+
+    fn reduce_naked_triples_in_all_units(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        for unit in Self::all_units() {
+            *changed |= Self::reduce_naked_triples_in_unit(grid, &unit);
         }
     }
 
-    fn reduce_possible_values_for_mutual_pairs_in_col(thread_grid: &Arc<Mutex<Grid>>, value_changed: &mut bool){
-        // pull the cells from the col into a Vec and pass to the common method.
+    fn reduce_naked_triples_in_unit(grid: &Arc<Mutex<Grid>>, cells: &[CellRef]) -> bool {
+        let mut changed = false;
+        let cell_poss = Self::read_unit_possibilities(grid, cells);
+
+        // Collect unsolved cells with 2 or 3 possibilities
+        let candidates: Vec<(usize, HashSet<i32>)> = cell_poss.iter().enumerate()
+            .filter(|(_, poss)| poss.len() == 2 || poss.len() == 3)
+            .map(|(i, poss)| (i, poss.iter().cloned().collect()))
+            .collect();
+
+        // Try all combinations of 3
+        for i in 0..candidates.len() {
+            for j in (i + 1)..candidates.len() {
+                for k in (j + 1)..candidates.len() {
+                    let union: HashSet<i32> = candidates[i].1
+                        .union(&candidates[j].1).cloned().collect::<HashSet<i32>>()
+                        .union(&candidates[k].1).cloned().collect();
+                    if union.len() == 3 {
+                        let idx_a = candidates[i].0;
+                        let idx_b = candidates[j].0;
+                        let idx_c = candidates[k].0;
+                        let mut g = grid.lock().unwrap();
+                        for (m, cr) in cells.iter().enumerate() {
+                            if m != idx_a && m != idx_b && m != idx_c {
+                                for &v in &union {
+                                    changed |= g.remove_possibility(cr.x, cr.y, v);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        changed
     }
 
-    fn reduce_possible_values_for_mutual_pairs_in_a_nine_cell_set(thread_grid: &Arc<Mutex<Grid>>, cells: Vec<Cell_Ref>) -> bool {
-        let mut vals_to_cells: HashMap<i32, Cell_Ref> = HashMap::new();
-        // allocate sets of Value_To_Cell_Refs for values 1..inc9 for the cells in the block
-        for cr in cells
-        {
-            // deref the grid
-            // get the cell poss values
-            // assign to hasMap
+    // =========================================================================
+    // Hidden Pairs: if two values in a unit can only appear in the same two
+    // cells, all other candidates can be removed from those two cells.
+    // =========================================================================
+
+    fn reduce_hidden_pairs_in_all_units(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        for unit in Self::all_units() {
+            *changed |= Self::reduce_hidden_pairs_in_unit(grid, &unit);
         }
-        // find numbers with only 2 options
-        // for this subset, check if any share the same cell_refs
-        // for those pair of cells, remove any other options from their possibilities
-        true
+    }
+
+    fn reduce_hidden_pairs_in_unit(grid: &Arc<Mutex<Grid>>, cells: &[CellRef]) -> bool {
+        let mut changed = false;
+        let cell_poss = Self::read_unit_possibilities(grid, cells);
+
+        // Map each value to the cell indices that can hold it
+        let mut value_locations: HashMap<i32, Vec<usize>> = HashMap::new();
+        for (i, poss) in cell_poss.iter().enumerate() {
+            for &v in poss {
+                value_locations.entry(v).or_default().push(i);
+            }
+        }
+
+        // Find values that appear in exactly 2 cells
+        let pair_values: Vec<(i32, Vec<usize>)> = value_locations.into_iter()
+            .filter(|(_, locs)| locs.len() == 2)
+            .collect();
+
+        // Check if any two such values share the same two cells
+        for i in 0..pair_values.len() {
+            for j in (i + 1)..pair_values.len() {
+                if pair_values[i].1 == pair_values[j].1 {
+                    let v1 = pair_values[i].0;
+                    let v2 = pair_values[j].0;
+                    let cell_a = pair_values[i].1[0];
+                    let cell_b = pair_values[i].1[1];
+                    // Remove all other candidates from these two cells
+                    let mut g = grid.lock().unwrap();
+                    for &idx in &[cell_a, cell_b] {
+                        let cr = &cells[idx];
+                        for &v in &cell_poss[idx] {
+                            if v != v1 && v != v2 {
+                                changed |= g.remove_possibility(cr.x, cr.y, v);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        changed
+    }
+
+    // =========================================================================
+    // Pointing Pairs: if a candidate in a block only appears in one row or
+    // column, it can be eliminated from that row/column outside the block.
+    // =========================================================================
+
+    fn reduce_pointing_pairs(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        for bx in 0..3_i32 {
+            for by in 0..3_i32 {
+                let block = Self::block_cells(bx, by);
+                let block_poss = Self::read_unit_possibilities(grid, &block);
+
+                for val in 1..=9 {
+                    let mut rows_with_val: HashSet<i32> = HashSet::new();
+                    let mut cols_with_val: HashSet<i32> = HashSet::new();
+                    let mut count = 0;
+
+                    for (i, poss) in block_poss.iter().enumerate() {
+                        if poss.contains(&val) {
+                            rows_with_val.insert(block[i].y);
+                            cols_with_val.insert(block[i].x);
+                            count += 1;
+                        }
+                    }
+
+                    if count < 2 { continue; }
+
+                    // All occurrences in the same row — eliminate from rest of that row
+                    if rows_with_val.len() == 1 {
+                        let row = *rows_with_val.iter().next().unwrap();
+                        let mut g = grid.lock().unwrap();
+                        for x in 0..9 {
+                            if x / 3 != bx {
+                                *changed |= g.remove_possibility(x, row, val);
+                            }
+                        }
+                    }
+
+                    // All occurrences in the same column — eliminate from rest of that column
+                    if cols_with_val.len() == 1 {
+                        let col = *cols_with_val.iter().next().unwrap();
+                        let mut g = grid.lock().unwrap();
+                        for y in 0..9 {
+                            if y / 3 != by {
+                                *changed |= g.remove_possibility(col, y, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Box/Line Reduction: if a candidate in a row/column only appears within
+    // one block, it can be eliminated from other cells in that block.
+    // =========================================================================
+
+    fn reduce_box_line(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        // Row-based: value in a row confined to one block
+        for row in 0..9_i32 {
+            let row_cells = Self::row_cells(row);
+            let row_poss = Self::read_unit_possibilities(grid, &row_cells);
+
+            for val in 1..=9 {
+                let mut blocks: HashSet<i32> = HashSet::new();
+                let mut count = 0;
+                for (i, poss) in row_poss.iter().enumerate() {
+                    if poss.contains(&val) {
+                        blocks.insert(row_cells[i].x / 3);
+                        count += 1;
+                    }
+                }
+                if count < 2 { continue; }
+                if blocks.len() == 1 {
+                    let bx = *blocks.iter().next().unwrap();
+                    let by = row / 3;
+                    let mut g = grid.lock().unwrap();
+                    for dy in 0..3 {
+                        let y = by * 3 + dy;
+                        if y != row {
+                            for dx in 0..3 {
+                                let x = bx * 3 + dx;
+                                *changed |= g.remove_possibility(x, y, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Column-based: value in a column confined to one block
+        for col in 0..9_i32 {
+            let col_cells = Self::col_cells(col);
+            let col_poss = Self::read_unit_possibilities(grid, &col_cells);
+
+            for val in 1..=9 {
+                let mut blocks: HashSet<i32> = HashSet::new();
+                let mut count = 0;
+                for (i, poss) in col_poss.iter().enumerate() {
+                    if poss.contains(&val) {
+                        blocks.insert(col_cells[i].y / 3);
+                        count += 1;
+                    }
+                }
+                if count < 2 { continue; }
+                if blocks.len() == 1 {
+                    let by = *blocks.iter().next().unwrap();
+                    let bx = col / 3;
+                    let mut g = grid.lock().unwrap();
+                    for dx in 0..3 {
+                        let x = bx * 3 + dx;
+                        if x != col {
+                            for dy in 0..3 {
+                                let y = by * 3 + dy;
+                                *changed |= g.remove_possibility(x, y, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/testdata/testdata.rs
+++ b/src/testdata/testdata.rs
@@ -71,4 +71,45 @@ impl TestData {
         grid.set_cell(3, 8, 7);
         grid.set_cell(7, 8, 1);
     }
+
+    pub fn set_test_data_hard(grid: &mut Grid) {
+        // A puzzle that requires naked pairs, pointing pairs, and
+        // box-line reduction beyond basic singles techniques.
+        // 1 . . | . . 7 | . 9 .
+        // . 3 . | . 2 . | . . 8
+        // . . 9 | 6 . . | 5 . .
+        // ------+-------+------
+        // . . 5 | 3 . . | 9 . .
+        // . 1 . | . 8 . | . 2 .
+        // 6 . . | . . 4 | . . 3
+        // ------+-------+------
+        // . . 7 | . . 8 | . . .
+        // . . . | . 3 . | . 8 .
+        // . 2 . | 4 . . | . . 1
+        grid.set_cell(0, 0, 1);
+        grid.set_cell(5, 0, 7);
+        grid.set_cell(7, 0, 9);
+        grid.set_cell(1, 1, 3);
+        grid.set_cell(4, 1, 2);
+        grid.set_cell(8, 1, 8);
+        grid.set_cell(2, 2, 9);
+        grid.set_cell(3, 2, 6);
+        grid.set_cell(6, 2, 5);
+        grid.set_cell(2, 3, 5);
+        grid.set_cell(3, 3, 3);
+        grid.set_cell(6, 3, 9);
+        grid.set_cell(1, 4, 1);
+        grid.set_cell(4, 4, 8);
+        grid.set_cell(7, 4, 2);
+        grid.set_cell(0, 5, 6);
+        grid.set_cell(5, 5, 4);
+        grid.set_cell(8, 5, 3);
+        grid.set_cell(2, 6, 7);
+        grid.set_cell(5, 6, 8);
+        grid.set_cell(4, 7, 3);
+        grid.set_cell(7, 7, 8);
+        grid.set_cell(1, 8, 2);
+        grid.set_cell(3, 8, 4);
+        grid.set_cell(8, 8, 1);
+    }
 }


### PR DESCRIPTION
## Summary
This PR significantly enhances the Sudoku solver by implementing advanced constraint propagation techniques beyond basic singles. The solver now uses naked pairs, naked triples, hidden pairs, pointing pairs, and box-line reduction to eliminate candidates more effectively.

## Key Changes

### Core API Updates
- Modified `Cell::remove_possibility()` to return `bool` indicating whether a possibility was actually removed
- Updated `Grid::remove_possibility()` to propagate the return value
- These changes enable tracking of solver progress through candidate elimination

### New Solver Techniques
- **Naked Pairs**: Identifies two cells in a unit with identical candidate pairs and eliminates those values from other cells
- **Naked Triples**: Extends naked pairs logic to three cells sharing exactly three candidate values
- **Hidden Pairs**: Finds two values that can only appear in the same two cells within a unit, then eliminates other candidates from those cells
- **Pointing Pairs**: When a candidate in a block appears in only one row/column, eliminates it from that row/column outside the block
- **Box/Line Reduction**: When a candidate in a row/column is confined to one block, eliminates it from other cells in that block

### Code Organization
- Refactored solver to use a unified `CellRef` struct for cell references
- Added helper methods (`row_cells()`, `col_cells()`, `block_cells()`, `all_units()`) for cleaner unit iteration
- Introduced `read_unit_possibilities()` for efficient batch reading of cell candidates
- Organized techniques into logical sections with clear comments
- Improved variable naming and code formatting throughout

### Testing
- Added `set_test_data_hard()` test case for puzzles requiring advanced techniques
- Removed outdated TODO items related to solve logic

## Implementation Details
- All new techniques follow the same pattern: read possibilities once per unit, identify patterns, then apply eliminations
- The solver continues iterating until no progress is made (no candidates eliminated and no values set)
- Return value tracking from `remove_possibility()` allows the solver to detect progress from candidate elimination alone

https://claude.ai/code/session_017KYg3ULikKotfm6rdYykQL