### PR TITLE
Add string-based puzzle input, direct cell editing UI, and 4 new solv…

### DIFF
--- a/src/grid/cell.rs
+++ b/src/grid/cell.rs
@@ -32,6 +32,11 @@ impl Cell {
         self.possible_values.len() < len_before
     }
 
+    pub fn clear(&mut self) {
+        self.value = 0;
+        self.possible_values = (1..=9).collect();
+    }
+
     pub fn possibilities(& self) -> &Vec<i32> {
         &self.possible_values
     }

--- a/src/grid/grid.rs
+++ b/src/grid/grid.rs
@@ -1,16 +1,49 @@
+use eframe::egui;
 use eframe::egui::Ui;
 use super::cell::Cell;
-use crate::EditingValues;
 
 pub struct Grid {
     cells: Vec<Cell>,
 }
 
-impl<'a> Grid {
+impl Grid {
     pub fn new() -> Self {
         Grid {
             cells : std::iter::repeat_with(Cell::new).take(81).collect(),
         }
+    }
+
+    /// Parse a puzzle from a string of digits.
+    /// Use 0 (or any non-1-9 digit) for blank cells.
+    /// All non-digit characters (spaces, newlines, etc.) are ignored.
+    ///
+    /// Example:
+    /// ```text
+    /// 000 050 030
+    /// 000 704 000
+    /// 100 300 049
+    /// 000 490 281
+    /// 032 580 900
+    /// 000 000 000
+    /// 965 000 000
+    /// 000 000 000
+    /// 007 200 000
+    /// ```
+    pub fn from_string(input: &str) -> Grid {
+        let mut grid = Grid::new();
+        let digits: Vec<i32> = input.chars()
+            .filter(|c| c.is_ascii_digit())
+            .map(|c| c.to_digit(10).unwrap() as i32)
+            .collect();
+
+        for (i, &val) in digits.iter().enumerate().take(81) {
+            if val > 0 {
+                let x = (i % 9) as i32;
+                let y = (i / 9) as i32;
+                let _ = grid.set_cell(x, y, val);
+            }
+        }
+        grid
     }
 
     pub fn add_cell(&mut self, cell: Cell) {
@@ -27,11 +60,11 @@ impl<'a> Grid {
             None => Err("No value found".to_string())
         }
     }
-    
+
     pub(crate) fn set_cell(& mut self, x: i32, y: i32, cell_value_int: i32) -> Result<(), String> {
-        
+
         if x<0 || x>8 || y<0 || y>8 {
-            return Err("The cell references are outside of the standard 9x9 grid.  Dimensions must be within 0..9:w".to_string());
+            return Err("The cell references are outside of the standard 9x9 grid.  Dimensions must be within 0..9".to_string());
         }
 
         // Set the cell value firstly
@@ -57,12 +90,53 @@ impl<'a> Grid {
         return Ok(());
     }
 
+    /// Clear a cell value and recalculate all possibilities from scratch.
+    pub fn clear_cell(&mut self, x: i32, y: i32) {
+        let index = (y * 9 + x) as usize;
+        self.cells[index].clear();
+        self.recalculate_possibilities();
+    }
+
+    /// Reset all unsolved cells' possibilities and re-propagate constraints
+    /// from every solved cell. Called after clearing a cell.
+    fn recalculate_possibilities(&mut self) {
+        // Reset all unsolved cells to full possibility set
+        for cell in &mut self.cells {
+            if cell.get_value() == 0 {
+                cell.clear();
+            }
+        }
+        // Re-propagate constraints from each solved cell
+        for y in 0..9_i32 {
+            for x in 0..9_i32 {
+                let index = (y * 9 + x) as usize;
+                let val = self.cells[index].get_value();
+                if val > 0 {
+                    for c in 0..9 {
+                        self.remove_possibility(c, y, val);
+                        self.remove_possibility(x, c, val);
+                    }
+                    let bx = x / 3 * 3;
+                    let by = y / 3 * 3;
+                    for dy in 0..3 {
+                        for dx in 0..3 {
+                            self.remove_possibility(bx + dx, by + dy, val);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     pub fn remove_possibility(&mut self, x:i32, y: i32, value: i32) -> bool {
         let index = (y * 9 + x) as usize;
         self.cells[index].remove_possibility(value)
     }
-    
-    pub fn render_grid(&self, ui: &mut Ui, edit_values: &mut EditingValues){
+
+    /// Render the grid. Highlights the selected cell.
+    /// Returns the (col, row) of a clicked cell, or None.
+    pub fn render_grid(&self, ui: &mut Ui, selected: Option<(i32, i32)>) -> Option<(i32, i32)> {
+        let mut clicked: Option<(i32, i32)> = None;
         for row in 0..9 {
             let mut bottom_pad = 2.0;
             if (row + 1) % 3 == 0 {
@@ -77,11 +151,15 @@ impl<'a> Grid {
                             if col % 3 == 0  && col != 0 {
                                 left_mgn = 10.0;
                             }
-                            let cell_val = self.get_cell(col, row).unwrap().get_value().to_string().replace("0", " "); 
-                            let mut bg_color = egui::Color32::GRAY;
-                            if cell_val == " " {
-                               bg_color = egui::Color32::WHITE; 
-                            }
+                            let cell_val = self.get_cell(col, row).unwrap().get_value().to_string().replace("0", " ");
+                            let is_selected = selected == Some((col, row));
+                            let bg_color = if is_selected {
+                                egui::Color32::from_rgb(173, 216, 230) // light blue
+                            } else if cell_val == " " {
+                                egui::Color32::WHITE
+                            } else {
+                                egui::Color32::GRAY
+                            };
                             egui::Frame::default()
                                 .stroke(ui.visuals().widgets.noninteractive.fg_stroke)
                                 .outer_margin(egui::Margin{left: left_mgn, right: 0.0, top: 0.0, bottom: 0.0})
@@ -89,23 +167,20 @@ impl<'a> Grid {
                                 .fill(bg_color)
                                 .show(ui, |ui| {
                                     ui.set_min_width(12.0);
-                                    if(ui.label(
+                                    if ui.label(
                                         egui::RichText::new(cell_val)
                                         .color(egui::Color32::BLACK)
                                         .size(20.0)
                                         .strong()
-                                    )).clicked(){
-                                        println!("Call to edit {},{}", col, row);
-                                        edit_values.new_value = true;
-                                        edit_values.row = row;
-                                        edit_values.col = col;
-                                        edit_values.value = self.get_cell(col, row).unwrap().get_value();
+                                    ).clicked() {
+                                        clicked = Some((col, row));
                                     };
                                 });
                         }
                     })
                 });
         }
+        clicked
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod grid;
 mod testdata;
 mod solver;
-use std::{thread, thread::sleep, time::Duration};
+use std::{thread, time::Duration};
 use std::sync::{Arc, Mutex};
 use eframe::egui;
 use grid::Grid;
@@ -9,7 +9,6 @@ use testdata::TestData;
 use solver::Solver;
 
 // TODO:
-// * Editing in cell, rather than at bottom
 // * Handle impossible grids
 // * Handle logic fails :
 //  * cells with no valid value (possibilities().len == 0)
@@ -18,84 +17,89 @@ use solver::Solver;
 // * Either handle result objects or remove them
 
 fn main() -> eframe::Result {
-    // Set up the main grid
-    let mut grid = Grid::new();
+    // Change TestData::expert() to simple(), medium(), or hard() to load a different puzzle.
+    let grid = TestData::expert();
 
-    TestData::set_test_data_medium(&mut grid);
-
-    // Form size.
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_inner_size([400.0, 540.0]),
         ..Default::default()
     };
 
-    eframe::run_native("Sudoku Solver", options, Box::new(|cc| Ok(Box::new(SudokuApp::new(grid, cc)))))
+    eframe::run_native("Sudoku Solver", options, Box::new(|_cc| Ok(Box::new(SudokuApp::new(grid)))))
 }
 
 struct SudokuApp {
-    pub grid : Arc<Mutex<Grid>>,
-    pub edit_values: EditingValues,
-}
-
-pub struct EditingValues{
-    pub row: i32,
-    pub col: i32,
-    pub value: i32,
-    pub value_as_string: String,
-    pub new_value: bool
-}
-
-impl EditingValues{
-    fn new() -> Self{
-        EditingValues { 
-            row: 9,
-            col: 9,
-            value: 0,
-            value_as_string: "".to_string(),
-            new_value: false,
-        }
-    }
+    pub grid: Arc<Mutex<Grid>>,
+    pub selected_cell: Option<(i32, i32)>,
 }
 
 impl SudokuApp {
-    fn new(grid:  Grid, cc: &eframe::CreationContext<'_>) -> Self {
-        let grid_mut = Arc::new(Mutex::new(grid));
+    fn new(grid: Grid) -> Self {
         Self {
-            grid: grid_mut,
-            edit_values: EditingValues::new(),
+            grid: Arc::new(Mutex::new(grid)),
+            selected_cell: None,
         }
     }
 }
 
 impl eframe::App for SudokuApp {
-    fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.heading("Click a Cell to set its value.");
-            self.edit_values.new_value = false;
-            let view_grid = Arc::clone(&self.grid);
-            (*view_grid.lock().unwrap()).render_grid(ui, &mut self.edit_values);
+            ui.heading("Click a cell, type 1-9. Delete to clear.");
+
+            // Render grid — returns which cell was clicked (if any)
+            let clicked = {
+                let grid = self.grid.lock().unwrap();
+                grid.render_grid(ui, self.selected_cell)
+            };
+
+            if let Some(cell) = clicked {
+                self.selected_cell = Some(cell);
+            }
+
+            // Handle keyboard input for the selected cell
+            if let Some((col, row)) = self.selected_cell {
+                let keys = [
+                    (egui::Key::Num1, 1), (egui::Key::Num2, 2), (egui::Key::Num3, 3),
+                    (egui::Key::Num4, 4), (egui::Key::Num5, 5), (egui::Key::Num6, 6),
+                    (egui::Key::Num7, 7), (egui::Key::Num8, 8), (egui::Key::Num9, 9),
+                ];
+                for &(key, num) in &keys {
+                    if ui.input(|i| i.key_pressed(key)) {
+                        let mut grid = self.grid.lock().unwrap();
+                        let _ = grid.set_cell(col, row, num);
+                    }
+                }
+                if ui.input(|i| i.key_pressed(egui::Key::Delete) || i.key_pressed(egui::Key::Backspace)) {
+                    let mut grid = self.grid.lock().unwrap();
+                    grid.clear_cell(col, row);
+                }
+                if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+                    self.selected_cell = None;
+                }
+                // Arrow key navigation
+                if ui.input(|i| i.key_pressed(egui::Key::ArrowRight)) {
+                    self.selected_cell = Some(((col + 1).min(8), row));
+                }
+                if ui.input(|i| i.key_pressed(egui::Key::ArrowLeft)) {
+                    self.selected_cell = Some(((col - 1).max(0), row));
+                }
+                if ui.input(|i| i.key_pressed(egui::Key::ArrowDown)) {
+                    self.selected_cell = Some((col, (row + 1).min(8)));
+                }
+                if ui.input(|i| i.key_pressed(egui::Key::ArrowUp)) {
+                    self.selected_cell = Some((col, (row - 1).max(0)));
+                }
+            }
 
             ctx.request_repaint_after(Duration::from_millis(200));
+
             if ui.button("Solve").clicked() {
                 let thread_grid = Arc::clone(&self.grid);
                 thread::spawn(move || {
-                    solver::Solver::solve(thread_grid);
+                    Solver::solve(thread_grid);
                 });
             };
-            if self.edit_values.row != 9 {
-                if self.edit_values.new_value {
-                    self.edit_values.value_as_string = self.edit_values.value.to_string();
-                }
-                let textbox = ui.text_edit_singleline(&mut self.edit_values.value_as_string);
-                if textbox.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                    if let Ok(parsed) = self.edit_values.value_as_string.parse::<i32>() {
-                        self.edit_values.value = parsed;
-                        let view_grid = Arc::clone(&self.grid);
-                        (*view_grid.lock().unwrap()).set_cell(self.edit_values.col, self.edit_values.row, self.edit_values.value);
-                        self.edit_values.row = 9;
-                    }
-                }
-            }
         });
     }
 }

--- a/src/solver/solver.rs
+++ b/src/solver/solver.rs
@@ -22,8 +22,12 @@ impl Solver {
             Self::reduce_naked_pairs_in_all_units(&thread_grid, &mut progress);
             Self::reduce_naked_triples_in_all_units(&thread_grid, &mut progress);
             Self::reduce_hidden_pairs_in_all_units(&thread_grid, &mut progress);
+            Self::reduce_hidden_triples_in_all_units(&thread_grid, &mut progress);
             Self::reduce_pointing_pairs(&thread_grid, &mut progress);
             Self::reduce_box_line(&thread_grid, &mut progress);
+            Self::reduce_x_wing(&thread_grid, &mut progress);
+            Self::reduce_swordfish(&thread_grid, &mut progress);
+            Self::reduce_y_wing(&thread_grid, &mut progress);
 
             // Value-setting techniques
             Self::set_only_one_possibility_values(&thread_grid, &mut progress);
@@ -84,8 +88,37 @@ impl Solver {
         }).collect()
     }
 
+    /// Read all 81 cells' possibilities in one lock. Index = y*9+x.
+    fn read_all_possibilities(grid: &Arc<Mutex<Grid>>) -> Vec<Vec<i32>> {
+        let g = grid.lock().unwrap();
+        let mut result = Vec::with_capacity(81);
+        for y in 0..9_i32 {
+            for x in 0..9_i32 {
+                let cell = g.get_cell(x, y).unwrap();
+                if cell.get_value() > 0 {
+                    result.push(Vec::new());
+                } else {
+                    result.push(cell.possibilities().clone());
+                }
+            }
+        }
+        result
+    }
+
+    /// Check whether two cells can see each other (same row, column, or block).
+    fn cells_see_each_other(x1: i32, y1: i32, x2: i32, y2: i32) -> bool {
+        if x1 == x2 && y1 == y2 { return false; }
+        // Same row
+        if y1 == y2 { return true; }
+        // Same column
+        if x1 == x2 { return true; }
+        // Same block
+        if x1 / 3 == x2 / 3 && y1 / 3 == y2 / 3 { return true; }
+        false
+    }
+
     // =========================================================================
-    // Existing value-setting techniques
+    // Value-setting techniques
     // =========================================================================
 
     /// Naked singles: if a cell has only one possibility left, set it.
@@ -385,6 +418,64 @@ impl Solver {
     }
 
     // =========================================================================
+    // Hidden Triples: if three values in a unit can only appear in the same
+    // three cells, all other candidates can be removed from those cells.
+    // =========================================================================
+
+    fn reduce_hidden_triples_in_all_units(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        for unit in Self::all_units() {
+            *changed |= Self::reduce_hidden_triples_in_unit(grid, &unit);
+        }
+    }
+
+    fn reduce_hidden_triples_in_unit(grid: &Arc<Mutex<Grid>>, cells: &[CellRef]) -> bool {
+        let mut changed = false;
+        let cell_poss = Self::read_unit_possibilities(grid, cells);
+
+        // Map each value to the cell indices that can hold it
+        let mut value_locations: HashMap<i32, Vec<usize>> = HashMap::new();
+        for (i, poss) in cell_poss.iter().enumerate() {
+            for &v in poss {
+                value_locations.entry(v).or_default().push(i);
+            }
+        }
+
+        // Find values that appear in 2 or 3 cells
+        let candidates: Vec<(i32, Vec<usize>)> = value_locations.into_iter()
+            .filter(|(_, locs)| locs.len() >= 2 && locs.len() <= 3)
+            .collect();
+
+        // Try all combinations of 3 values
+        for i in 0..candidates.len() {
+            for j in (i + 1)..candidates.len() {
+                for k in (j + 1)..candidates.len() {
+                    let cell_union: HashSet<usize> = candidates[i].1.iter()
+                        .chain(candidates[j].1.iter())
+                        .chain(candidates[k].1.iter())
+                        .cloned().collect();
+
+                    if cell_union.len() == 3 {
+                        let v1 = candidates[i].0;
+                        let v2 = candidates[j].0;
+                        let v3 = candidates[k].0;
+                        // Remove all other candidates from these 3 cells
+                        let mut g = grid.lock().unwrap();
+                        for &idx in &cell_union {
+                            let cr = &cells[idx];
+                            for &v in &cell_poss[idx] {
+                                if v != v1 && v != v2 && v != v3 {
+                                    changed |= g.remove_possibility(cr.x, cr.y, v);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        changed
+    }
+
+    // =========================================================================
     // Pointing Pairs: if a candidate in a block only appears in one row or
     // column, it can be eliminated from that row/column outside the block.
     // =========================================================================
@@ -499,6 +590,228 @@ impl Solver {
                             for dy in 0..3 {
                                 let y = by * 3 + dy;
                                 *changed |= g.remove_possibility(x, y, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // X-Wing: if a candidate appears in exactly 2 cells in each of 2 rows,
+    // and those cells share the same 2 columns, eliminate it from other cells
+    // in those columns (and vice versa for columns → rows).
+    // =========================================================================
+
+    fn reduce_x_wing(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        let all_poss = Self::read_all_possibilities(grid);
+
+        for val in 1..=9_i32 {
+            // Row-based X-Wing
+            // For each row, find which columns hold this candidate
+            let mut row_cols: Vec<Vec<i32>> = Vec::new();
+            for row in 0..9_i32 {
+                let cols: Vec<i32> = (0..9_i32)
+                    .filter(|&col| all_poss[(row * 9 + col) as usize].contains(&val))
+                    .collect();
+                row_cols.push(cols);
+            }
+
+            for r1 in 0..9_usize {
+                if row_cols[r1].len() != 2 { continue; }
+                for r2 in (r1 + 1)..9 {
+                    if row_cols[r2].len() != 2 { continue; }
+                    if row_cols[r1] == row_cols[r2] {
+                        // X-Wing found: eliminate val from these 2 columns in other rows
+                        let c1 = row_cols[r1][0];
+                        let c2 = row_cols[r1][1];
+                        let mut g = grid.lock().unwrap();
+                        for row in 0..9_i32 {
+                            if row != r1 as i32 && row != r2 as i32 {
+                                *changed |= g.remove_possibility(c1, row, val);
+                                *changed |= g.remove_possibility(c2, row, val);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Column-based X-Wing
+            // For each column, find which rows hold this candidate
+            let mut col_rows: Vec<Vec<i32>> = Vec::new();
+            for col in 0..9_i32 {
+                let rows: Vec<i32> = (0..9_i32)
+                    .filter(|&row| all_poss[(row * 9 + col) as usize].contains(&val))
+                    .collect();
+                col_rows.push(rows);
+            }
+
+            for c1 in 0..9_usize {
+                if col_rows[c1].len() != 2 { continue; }
+                for c2 in (c1 + 1)..9 {
+                    if col_rows[c2].len() != 2 { continue; }
+                    if col_rows[c1] == col_rows[c2] {
+                        // X-Wing found: eliminate val from these 2 rows in other columns
+                        let r1 = col_rows[c1][0];
+                        let r2 = col_rows[c1][1];
+                        let mut g = grid.lock().unwrap();
+                        for col in 0..9_i32 {
+                            if col != c1 as i32 && col != c2 as i32 {
+                                *changed |= g.remove_possibility(col, r1, val);
+                                *changed |= g.remove_possibility(col, r2, val);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Swordfish: extension of X-Wing to 3 rows/columns. If a candidate
+    // appears in 2-3 positions in each of 3 rows, and all those positions
+    // fall within the same 3 columns, eliminate it from other cells in
+    // those columns (and vice versa).
+    // =========================================================================
+
+    fn reduce_swordfish(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        let all_poss = Self::read_all_possibilities(grid);
+
+        for val in 1..=9_i32 {
+            // Row-based Swordfish
+            let mut row_cols: Vec<(i32, Vec<i32>)> = Vec::new();
+            for row in 0..9_i32 {
+                let cols: Vec<i32> = (0..9_i32)
+                    .filter(|&col| all_poss[(row * 9 + col) as usize].contains(&val))
+                    .collect();
+                if cols.len() >= 2 && cols.len() <= 3 {
+                    row_cols.push((row, cols));
+                }
+            }
+
+            for i in 0..row_cols.len() {
+                for j in (i + 1)..row_cols.len() {
+                    for k in (j + 1)..row_cols.len() {
+                        let col_union: HashSet<i32> = row_cols[i].1.iter()
+                            .chain(row_cols[j].1.iter())
+                            .chain(row_cols[k].1.iter())
+                            .cloned().collect();
+
+                        if col_union.len() == 3 {
+                            let rows = [row_cols[i].0, row_cols[j].0, row_cols[k].0];
+                            let mut g = grid.lock().unwrap();
+                            for &col in &col_union {
+                                for row in 0..9_i32 {
+                                    if !rows.contains(&row) {
+                                        *changed |= g.remove_possibility(col, row, val);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Column-based Swordfish
+            let mut col_rows: Vec<(i32, Vec<i32>)> = Vec::new();
+            for col in 0..9_i32 {
+                let rows: Vec<i32> = (0..9_i32)
+                    .filter(|&row| all_poss[(row * 9 + col) as usize].contains(&val))
+                    .collect();
+                if rows.len() >= 2 && rows.len() <= 3 {
+                    col_rows.push((col, rows));
+                }
+            }
+
+            for i in 0..col_rows.len() {
+                for j in (i + 1)..col_rows.len() {
+                    for k in (j + 1)..col_rows.len() {
+                        let row_union: HashSet<i32> = col_rows[i].1.iter()
+                            .chain(col_rows[j].1.iter())
+                            .chain(col_rows[k].1.iter())
+                            .cloned().collect();
+
+                        if row_union.len() == 3 {
+                            let cols = [col_rows[i].0, col_rows[j].0, col_rows[k].0];
+                            let mut g = grid.lock().unwrap();
+                            for &row in &row_union {
+                                for col in 0..9_i32 {
+                                    if !cols.contains(&col) {
+                                        *changed |= g.remove_possibility(col, row, val);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // Y-Wing (XY-Wing): a pivot cell with candidates {A,B} connects to two
+    // wing cells — one with {A,C} and one with {B,C}. Any cell that sees
+    // both wings cannot contain C.
+    // =========================================================================
+
+    fn reduce_y_wing(grid: &Arc<Mutex<Grid>>, changed: &mut bool) {
+        let all_poss = Self::read_all_possibilities(grid);
+
+        // Collect all bivalue cells (exactly 2 candidates)
+        let bivalue: Vec<(i32, i32, Vec<i32>)> = all_poss.iter().enumerate()
+            .filter(|(_, poss)| poss.len() == 2)
+            .map(|(idx, poss)| {
+                let x = (idx % 9) as i32;
+                let y = (idx / 9) as i32;
+                let mut sorted = poss.clone();
+                sorted.sort();
+                (x, y, sorted)
+            })
+            .collect();
+
+        // For each potential pivot
+        for pivot in &bivalue {
+            let (px, py, pvals) = pivot;
+            let a = pvals[0];
+            let b = pvals[1];
+
+            // Find wings that see the pivot
+            let mut wings_ac: Vec<&(i32, i32, Vec<i32>)> = Vec::new(); // contain A but not B
+            let mut wings_bc: Vec<&(i32, i32, Vec<i32>)> = Vec::new(); // contain B but not A
+
+            for wing in &bivalue {
+                let (wx, wy, wvals) = wing;
+                if wx == px && wy == py { continue; }
+                if !Self::cells_see_each_other(*px, *py, *wx, *wy) { continue; }
+
+                if wvals.contains(&a) && !wvals.contains(&b) {
+                    wings_ac.push(wing);
+                }
+                if wvals.contains(&b) && !wvals.contains(&a) {
+                    wings_bc.push(wing);
+                }
+            }
+
+            // For each pair of wings (one AC, one BC)
+            for wa in &wings_ac {
+                for wb in &wings_bc {
+                    // Find C: the shared value between the two wings that isn't A or B
+                    let c_candidates: Vec<i32> = wa.2.iter()
+                        .filter(|&&v| v != a && wb.2.contains(&v))
+                        .cloned().collect();
+                    if c_candidates.len() != 1 { continue; }
+                    let c = c_candidates[0];
+
+                    // Eliminate C from all cells that see BOTH wings
+                    let mut g = grid.lock().unwrap();
+                    for y in 0..9_i32 {
+                        for x in 0..9_i32 {
+                            if (x == wa.0 && y == wa.1) || (x == wb.0 && y == wb.1) { continue; }
+                            if x == *px && y == *py { continue; }
+                            if Self::cells_see_each_other(x, y, wa.0, wa.1)
+                                && Self::cells_see_each_other(x, y, wb.0, wb.1) {
+                                *changed |= g.remove_possibility(x, y, c);
                             }
                         }
                     }

--- a/src/testdata/testdata.rs
+++ b/src/testdata/testdata.rs
@@ -1,115 +1,60 @@
 use crate::Grid;
-pub struct TestData{
+
+pub struct TestData {
 }
 
 impl TestData {
-    pub fn set_test_data_simple(grid: &mut Grid) {
-        grid.set_cell(0, 0, 3);
-        grid.set_cell(5, 0, 2);
-        grid.set_cell(6, 0, 9);
-        grid.set_cell(7, 0, 6);
-        grid.set_cell(0, 1, 1);
-        grid.set_cell(1, 1, 4);
-        grid.set_cell(6, 1, 2);
-        grid.set_cell(8, 1, 8);
-        grid.set_cell(2, 2, 2);
-        grid.set_cell(3, 2, 9);
-        grid.set_cell(4, 2, 7);
-        grid.set_cell(5, 2, 1);
-        grid.set_cell(2, 3, 1);
-        grid.set_cell(3, 3, 4);
-        grid.set_cell(7, 3, 2);
-        grid.set_cell(8, 3, 6);
-        grid.set_cell(0, 4, 2);
-        grid.set_cell(2, 4, 4);
-        grid.set_cell(4, 4, 8);
-        grid.set_cell(5, 4, 5);
-        grid.set_cell(7, 4, 9);
-        grid.set_cell(0, 5, 7);
-        grid.set_cell(2, 5, 8);
-        grid.set_cell(4, 5, 1);
-        grid.set_cell(8, 5, 3);
-        grid.set_cell(0, 6, 4);
-        grid.set_cell(1, 6, 5);
-        grid.set_cell(2, 6, 3);
-        grid.set_cell(7, 6, 1);
-        grid.set_cell(1, 7, 1);
-        grid.set_cell(3, 7, 7);
-        grid.set_cell(4, 7, 5);
-        grid.set_cell(5, 7, 4);
-        grid.set_cell(2, 8, 7);
-        grid.set_cell(3, 8, 1);
-        grid.set_cell(5, 8, 9);
-        grid.set_cell(6, 8, 6);
-        grid.set_cell(8, 8, 4);
+    pub fn simple() -> Grid {
+        Grid::from_string("\
+            300 002 960\
+            140 000 208\
+            002 971 000\
+            001 400 026\
+            204 085 090\
+            708 010 003\
+            453 000 010\
+            010 754 000\
+            007 109 604")
     }
 
-    pub fn set_test_data_medium(grid: &mut Grid) {
-        grid.set_cell(2, 0, 2);
-        grid.set_cell(3, 0, 5);
-        grid.set_cell(5, 0, 3);
-        grid.set_cell(2, 1, 8);
-        grid.set_cell(4, 1, 6);
-        grid.set_cell(4, 2, 2);
-        grid.set_cell(7, 2, 5);
-        grid.set_cell(8, 2, 9);
-        grid.set_cell(3, 3, 6);
-        grid.set_cell(4, 3, 8);
-        grid.set_cell(5, 3, 9);
-        grid.set_cell(6, 3, 3);
-        grid.set_cell(8, 3, 5);
-        grid.set_cell(7, 4, 8);
-        grid.set_cell(1, 5, 2);
-        grid.set_cell(5, 5, 5);
-        grid.set_cell(8, 5, 6);
-        grid.set_cell(2, 6, 7);
-        grid.set_cell(6, 6, 2);
-        grid.set_cell(8, 6, 4);
-        grid.set_cell(3, 7, 8);
-        grid.set_cell(5, 7, 4);
-        grid.set_cell(2, 8, 9);
-        grid.set_cell(3, 8, 7);
-        grid.set_cell(7, 8, 1);
+    pub fn medium() -> Grid {
+        Grid::from_string("\
+            002 503 000\
+            008 060 000\
+            000 020 059\
+            000 689 305\
+            000 000 080\
+            020 005 006\
+            007 000 204\
+            000 804 000\
+            009 700 010")
     }
 
-    pub fn set_test_data_hard(grid: &mut Grid) {
-        // A puzzle that requires naked pairs, pointing pairs, and
-        // box-line reduction beyond basic singles techniques.
-        // 1 . . | . . 7 | . 9 .
-        // . 3 . | . 2 . | . . 8
-        // . . 9 | 6 . . | 5 . .
-        // ------+-------+------
-        // . . 5 | 3 . . | 9 . .
-        // . 1 . | . 8 . | . 2 .
-        // 6 . . | . . 4 | . . 3
-        // ------+-------+------
-        // . . 7 | . . 8 | . . .
-        // . . . | . 3 . | . 8 .
-        // . 2 . | 4 . . | . . 1
-        grid.set_cell(0, 0, 1);
-        grid.set_cell(5, 0, 7);
-        grid.set_cell(7, 0, 9);
-        grid.set_cell(1, 1, 3);
-        grid.set_cell(4, 1, 2);
-        grid.set_cell(8, 1, 8);
-        grid.set_cell(2, 2, 9);
-        grid.set_cell(3, 2, 6);
-        grid.set_cell(6, 2, 5);
-        grid.set_cell(2, 3, 5);
-        grid.set_cell(3, 3, 3);
-        grid.set_cell(6, 3, 9);
-        grid.set_cell(1, 4, 1);
-        grid.set_cell(4, 4, 8);
-        grid.set_cell(7, 4, 2);
-        grid.set_cell(0, 5, 6);
-        grid.set_cell(5, 5, 4);
-        grid.set_cell(8, 5, 3);
-        grid.set_cell(2, 6, 7);
-        grid.set_cell(5, 6, 8);
-        grid.set_cell(4, 7, 3);
-        grid.set_cell(7, 7, 8);
-        grid.set_cell(1, 8, 2);
-        grid.set_cell(3, 8, 4);
-        grid.set_cell(8, 8, 1);
+    pub fn hard() -> Grid {
+        // Previous hard puzzle
+        Grid::from_string("\
+            100 007 090\
+            030 020 008\
+            009 600 500\
+            005 300 900\
+            010 080 020\
+            600 004 003\
+            007 008 000\
+            000 030 080\
+            020 400 001")
+    }
+
+    pub fn expert() -> Grid {
+        // Very hard puzzle requiring advanced techniques
+        Grid::from_string("\
+            000 050 030\
+            000 704 000\
+            100 300 049\
+            000 490 281\
+            032 580 900\
+            000 000 000\
+            965 000 000\
+            000 000 000\
+            007 200 000")
     }
 }


### PR DESCRIPTION
…er techniques

Grid & data:
- Add Grid::from_string() to parse puzzles from a simple digit string format
- Add Cell::clear() and Grid::clear_cell() with full possibility recalculation
- Rewrite testdata.rs to use the string format (much easier to add puzzles)
- Add expert-level test puzzle

UI improvements:
- Click a cell to select it (highlighted in blue), then type 1-9 to set value
- Delete/Backspace clears a cell, Escape deselects, arrow keys navigate
- Remove the old text input box at the bottom

New solver techniques:
- X-Wing: eliminate candidates when 2 rows share the same 2 column positions
- Swordfish: extension of X-Wing to 3 rows/columns
- Hidden Triples: if 3 values are confined to 3 cells, strip other candidates
- Y-Wing (XY-Wing): pivot + two wings eliminate a shared candidate

https://claude.ai/code/session_017KYg3ULikKotfm6rdYykQL