### PR TITLE
Add Clear Grid button and highlight user-entered cells in green

### DIFF
--- a/src/grid/cell.rs
+++ b/src/grid/cell.rs
@@ -1,12 +1,14 @@
 pub struct Cell {
     value: i32,
-    possible_values : Vec<i32>
+    possible_values : Vec<i32>,
+    user_entered: bool,
 }
 
 impl Cell {
     pub fn new() -> Self {
         Cell { value: 0,
         possible_values: (1..=9).collect(),
+        user_entered: false,
         }
     }
 
@@ -35,6 +37,15 @@ impl Cell {
     pub fn clear(&mut self) {
         self.value = 0;
         self.possible_values = (1..=9).collect();
+        self.user_entered = false;
+    }
+
+    pub fn is_user_entered(&self) -> bool {
+        self.user_entered
+    }
+
+    pub fn set_user_entered(&mut self, entered: bool) {
+        self.user_entered = entered;
     }
 
     pub fn possibilities(& self) -> &Vec<i32> {

--- a/src/grid/grid.rs
+++ b/src/grid/grid.rs
@@ -128,6 +128,17 @@ impl Grid {
         }
     }
 
+    /// Mark a cell as user-entered (for display purposes).
+    pub fn mark_user_entered(&mut self, x: i32, y: i32) {
+        let index = (y * 9 + x) as usize;
+        self.cells[index].set_user_entered(true);
+    }
+
+    /// Reset the entire grid to empty.
+    pub fn clear_all(&mut self) {
+        self.cells = std::iter::repeat_with(Cell::new).take(81).collect();
+    }
+
     pub fn remove_possibility(&mut self, x:i32, y: i32, value: i32) -> bool {
         let index = (y * 9 + x) as usize;
         self.cells[index].remove_possibility(value)
@@ -151,12 +162,16 @@ impl Grid {
                             if col % 3 == 0  && col != 0 {
                                 left_mgn = 10.0;
                             }
-                            let cell_val = self.get_cell(col, row).unwrap().get_value().to_string().replace("0", " ");
+                            let cell = self.get_cell(col, row).unwrap();
+                            let cell_val = cell.get_value().to_string().replace("0", " ");
+                            let is_user = cell.is_user_entered();
                             let is_selected = selected == Some((col, row));
                             let bg_color = if is_selected {
                                 egui::Color32::from_rgb(173, 216, 230) // light blue
                             } else if cell_val == " " {
                                 egui::Color32::WHITE
+                            } else if is_user {
+                                egui::Color32::from_rgb(144, 238, 144) // light green for user-entered
                             } else {
                                 egui::Color32::GRAY
                             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ impl eframe::App for SudokuApp {
                     if ui.input(|i| i.key_pressed(key)) {
                         let mut grid = self.grid.lock().unwrap();
                         let _ = grid.set_cell(col, row, num);
+                        grid.mark_user_entered(col, row);
                     }
                 }
                 if ui.input(|i| i.key_pressed(egui::Key::Delete) || i.key_pressed(egui::Key::Backspace)) {
@@ -94,12 +95,19 @@ impl eframe::App for SudokuApp {
 
             ctx.request_repaint_after(Duration::from_millis(200));
 
-            if ui.button("Solve").clicked() {
-                let thread_grid = Arc::clone(&self.grid);
-                thread::spawn(move || {
-                    Solver::solve(thread_grid);
-                });
-            };
+            ui.horizontal(|ui| {
+                if ui.button("Solve").clicked() {
+                    let thread_grid = Arc::clone(&self.grid);
+                    thread::spawn(move || {
+                        Solver::solve(thread_grid);
+                    });
+                }
+                if ui.button("Clear Grid").clicked() {
+                    let mut grid = self.grid.lock().unwrap();
+                    grid.clear_all();
+                    self.selected_cell = None;
+                }
+            });
         });
     }
 }


### PR DESCRIPTION
- Add user_entered flag to Cell, tracked through set/clear lifecycle
- User-entered cells display with a light green background
- Cleared cells lose their user-entered status
- Solver-set and loaded cells remain gray
- Add Clear Grid button that resets the entire grid to empty
- Place Solve and Clear Grid buttons side by side

https://claude.ai/code/session_017KYg3ULikKotfm6rdYykQL